### PR TITLE
Add fixes for fee-tier & collect-fees

### DIFF
--- a/src/admin/orca-admin.ts
+++ b/src/admin/orca-admin.ts
@@ -21,6 +21,7 @@ import {
   toX64,
   NUM_REWARDS,
   TickSpacing,
+  getFeeTierPda,
 } from "@orca-so/whirlpool-client-sdk";
 
 export class OrcaAdmin {
@@ -41,6 +42,8 @@ export class OrcaAdmin {
       tickSpacing
     );
 
+    const feeTierPda = getFeeTierPda(programId, whirlpoolConfigKey, tickSpacing);
+
     const tx = client.initPoolTx({
       initSqrtPrice,
       whirlpoolConfigKey,
@@ -50,6 +53,7 @@ export class OrcaAdmin {
       tokenVaultAKeypair: Keypair.generate(),
       tokenVaultBKeypair: Keypair.generate(),
       tickSpacing,
+      feeTierKey: feeTierPda.publicKey,
       funder: provider.wallet.publicKey,
     });
 

--- a/src/position/txs/fees-and-rewards.ts
+++ b/src/position/txs/fees-and-rewards.ts
@@ -91,8 +91,6 @@ export async function getMultipleCollectFeesAndRewardsTx(
         tokenOwnerAccountB,
         tokenVaultA: whirlpool.tokenVaultA,
         tokenVaultB: whirlpool.tokenVaultB,
-        tickArrayLower,
-        tickArrayUpper,
       })
       .compressIx(false);
     collectInstructions.push(feeIx);
@@ -122,8 +120,6 @@ export async function getMultipleCollectFeesAndRewardsTx(
             positionTokenAccount,
             rewardOwnerAccount,
             rewardVault: rewardInfo.vault,
-            tickArrayLower,
-            tickArrayUpper,
             rewardIndex: i,
           })
           .compressIx(false);

--- a/test/e2e/swap-e2e.test.ts
+++ b/test/e2e/swap-e2e.test.ts
@@ -1,4 +1,4 @@
-import { toX64 } from "@orca-so/whirlpool-client-sdk";
+import { TickSpacing, toX64 } from "@orca-so/whirlpool-client-sdk";
 import { BN, Provider } from "@project-serum/anchor";
 import { PublicKey } from "@solana/web3.js";
 import { Decimal } from "decimal.js";
@@ -9,6 +9,7 @@ import { getDefaultOffchainDataURI } from "../../src/constants/defaults";
 import { OrcaDAL } from "../../src/dal/orca-dal";
 import { ZERO } from "../../src/utils/web3/math-utils";
 import {
+  DEFAULT_FEE_RATE,
   initPoolWithLiquidity,
   initStandardPoolWithLiquidity,
   initWhirlpoolsConfig,


### PR DESCRIPTION
- initWhirlpoolsConfig will now call initFeeTier
- by default, will initialize standard tickSpacing with default fee rate
- OrcaAdmin.getInitPoolTx fetches feeTier for corresponding TickSpacing when creating pool
- Fix code for collect-fees API change

## NOTE:
- web will have to make sure that their respective FeeTier account is live prior to calling initPool. They can create a new feeTierAccount using `getInitPoolTx`
- All tests passes