### PR TITLE
Passing the refresh flag in certain cases

### DIFF
--- a/src/position/convert-data.ts
+++ b/src/position/convert-data.ts
@@ -22,13 +22,13 @@ export async function convertPositionDataToUserPositionData(
   const result: Record<string, UserPositionData> = {};
   for (const address of positionAddresses) {
     const positionId = toPubKey(address).toBase58();
-    const position = await dal.getPosition(address, false);
+    const position = await dal.getPosition(address, refresh);
     if (!position) {
       console.error(`error - position not found`);
       continue;
     }
 
-    const whirlpool = await dal.getPool(position.whirlpool, false);
+    const whirlpool = await dal.getPool(position.whirlpool, refresh);
     if (!whirlpool) {
       console.error(`error - whirlpool not found`);
       continue;
@@ -122,7 +122,7 @@ async function getUserPositions(
     }
   });
 
-  const positions = await dal.listPositions(potentialPositionAddresses, false);
+  const positions = await dal.listPositions(potentialPositionAddresses, refresh);
   invariant(potentialPositionAddresses.length === positions.length, "not enough positions data");
 
   if (refresh) {
@@ -133,7 +133,7 @@ async function getUserPositions(
         whirlpoolAddresses.add(position.whirlpool.toBase58());
       }
     });
-    const pools = await dal.listPools(Array.from(whirlpoolAddresses), false);
+    const pools = await dal.listPools(Array.from(whirlpoolAddresses), refresh);
 
     /*** Refresh mint infos ***/
     const allMintInfos: Set<string> = new Set();


### PR DESCRIPTION
we don't want to pass `refresh` everywhere, unfortunately, because it causes the application to make a _ton_ of requests that aren't strictly necessary. the two pieces that critical to refresh are the pool and the position, and i could be convinced that only the latter is important in the short-term.

without this change, calls to refresh the user position will continue to return a cached position due to https://github.com/orca-so/whirlpool-sdk/blob/cafa97233bea5c9b3ab3e4b626449d94ce6fba68/src/position/convert-data.ts#L25