### PR TITLE
Handling fee & rewards quotes when global growths overflow

### DIFF
--- a/src/position/quotes/collect-fees.ts
+++ b/src/position/quotes/collect-fees.ts
@@ -1,6 +1,6 @@
 import { WhirlpoolData, PositionData, TickData } from "@orca-so/whirlpool-client-sdk";
 import { BN } from "@project-serum/anchor";
-import { subUnderflowU128, U128, ZERO } from "../../utils/web3/math-utils";
+import { subUnderflowU128 } from "../../utils/web3/math-utils";
 import { CollectFeesQuote } from "../public";
 
 export type InternalGetCollectFeesQuoteParam = {
@@ -44,8 +44,8 @@ export function getCollectFeesQuoteInternal(
   let feeGrowthBelowBX64: BN | null = null;
 
   if (tickCurrentIndex < tickLowerIndex) {
-    feeGrowthBelowAX64 = feeGrowthGlobalAX64.sub(tickLowerFeeGrowthOutsideAX64);
-    feeGrowthBelowBX64 = feeGrowthGlobalBX64.sub(tickLowerFeeGrowthOutsideBX64);
+    feeGrowthBelowAX64 = subUnderflowU128(feeGrowthGlobalAX64, tickLowerFeeGrowthOutsideAX64);
+    feeGrowthBelowBX64 = subUnderflowU128(feeGrowthGlobalBX64, tickLowerFeeGrowthOutsideBX64);
   } else {
     feeGrowthBelowAX64 = tickLowerFeeGrowthOutsideAX64;
     feeGrowthBelowBX64 = tickLowerFeeGrowthOutsideBX64;
@@ -58,16 +58,16 @@ export function getCollectFeesQuoteInternal(
     feeGrowthAboveAX64 = tickUpperFeeGrowthOutsideAX64;
     feeGrowthAboveBX64 = tickUpperFeeGrowthOutsideBX64;
   } else {
-    feeGrowthAboveAX64 = feeGrowthGlobalAX64.sub(tickUpperFeeGrowthOutsideAX64);
-    feeGrowthAboveBX64 = feeGrowthGlobalBX64.sub(tickUpperFeeGrowthOutsideBX64);
+    feeGrowthAboveAX64 = subUnderflowU128(feeGrowthGlobalAX64, tickUpperFeeGrowthOutsideAX64);
+    feeGrowthAboveBX64 = subUnderflowU128(feeGrowthGlobalBX64, tickUpperFeeGrowthOutsideBX64);
   }
 
   const feeGrowthInsideAX64 = subUnderflowU128(
-    feeGrowthGlobalAX64.sub(feeGrowthBelowAX64),
+    subUnderflowU128(feeGrowthGlobalAX64, feeGrowthBelowAX64),
     feeGrowthAboveAX64
   );
   const feeGrowthInsideBX64 = subUnderflowU128(
-    feeGrowthGlobalBX64.sub(feeGrowthBelowBX64),
+    subUnderflowU128(feeGrowthGlobalBX64, feeGrowthBelowBX64),
     feeGrowthAboveBX64
   );
 

--- a/src/position/quotes/collect-rewards.ts
+++ b/src/position/quotes/collect-rewards.ts
@@ -1,7 +1,7 @@
 import { NUM_REWARDS, PositionData, TickData, WhirlpoolData } from "@orca-so/whirlpool-client-sdk";
 import { BN } from "@project-serum/anchor";
 import invariant from "tiny-invariant";
-import { subUnderflowU128, U128, ZERO } from "../../utils/web3/math-utils";
+import { subUnderflowU128 } from "../../utils/web3/math-utils";
 import { PoolUtil } from "../../utils/whirlpool/pool-util";
 import { CollectRewardsQuote } from "../public";
 
@@ -37,7 +37,7 @@ export function getCollectRewardsQuoteInternal(
     invariant(!!upperRewardGrowthsOutside, "upperRewardGrowthsOutside cannot be undefined");
 
     if (tickCurrentIndex < tickLowerIndex) {
-      rewardGrowthsBelowX64[i] = growthGlobalX64.sub(lowerRewardGrowthsOutside);
+      rewardGrowthsBelowX64[i] = subUnderflowU128(growthGlobalX64, lowerRewardGrowthsOutside);
     } else {
       rewardGrowthsBelowX64[i] = lowerRewardGrowthsOutside;
     }
@@ -45,7 +45,7 @@ export function getCollectRewardsQuoteInternal(
     if (tickCurrentIndex < tickUpperIndex) {
       rewardGrowthsAboveX64[i] = upperRewardGrowthsOutside;
     } else {
-      rewardGrowthsAboveX64[i] = growthGlobalX64.sub(upperRewardGrowthsOutside);
+      rewardGrowthsAboveX64[i] = subUnderflowU128(growthGlobalX64, upperRewardGrowthsOutside);
     }
   }
 
@@ -64,7 +64,7 @@ export function getCollectRewardsQuoteInternal(
       invariant(!!growthAboveX64, "growthAboveX64 cannot be undefined");
 
       const growthInsde = subUnderflowU128(
-        rewardInfo.growthGlobalX64.sub(growthBelowX64),
+        subUnderflowU128(rewardInfo.growthGlobalX64, growthBelowX64),
         growthAboveX64
       );
       rewardGrowthsInsideX64[i] = [growthInsde, true];


### PR DESCRIPTION
Changes
- Add wrapping sub to handle tick calculation underflows when global growth accumulators overflow

Related PR - specifically `tick_manager` and `position_manager`
- https://github.com/orca-so/whirlpool/pull/175