### PR TITLE
Remove TickSpacing enum from SDK

### DIFF
--- a/src/admin/orca-admin.ts
+++ b/src/admin/orca-admin.ts
@@ -21,7 +21,6 @@ import {
   WhirlpoolClient,
   getWhirlpoolPda,
   NUM_REWARDS,
-  TickSpacing,
   getFeeTierPda,
 } from "@orca-so/whirlpool-client-sdk";
 import { resolveOrCreateATA } from "../utils/web3/ata-utils";
@@ -30,12 +29,11 @@ export class OrcaAdmin {
   constructor(private readonly dal: OrcaDAL) {}
 
   public getInitPoolTx(param: InitPoolTxParam): { tx: TransactionBuilder; address: PublicKey } {
-    const { provider, initSqrtPrice, tokenMintA, tokenMintB, stable } = param;
+    const { provider, initSqrtPrice, tokenMintA, tokenMintB, tickSpacing } = param;
     const { programId, whirlpoolsConfig: whirlpoolConfigKey } = this.dal;
     const ctx = WhirlpoolContext.withProvider(provider, programId);
     const client = new WhirlpoolClient(ctx);
 
-    const tickSpacing = stable ? TickSpacing.Stable : TickSpacing.Standard;
     const whirlpoolPda = getWhirlpoolPda(
       programId,
       whirlpoolConfigKey,

--- a/src/admin/public/config.ts
+++ b/src/admin/public/config.ts
@@ -2,7 +2,6 @@ import {
   TransactionBuilder,
   WhirlpoolContext,
   WhirlpoolClient,
-  TickSpacing,
   InitFeeTierParams,
   getFeeTierPda,
 } from "@orca-so/whirlpool-client-sdk";
@@ -47,7 +46,7 @@ export type InitFeeTierConfigTxParam = {
   provider: Provider;
   whirlpoolConfigKey: Address;
   feeAuthority: Address;
-  tickSpacing: TickSpacing;
+  tickSpacing: number;
   defaultFeeRate: number;
 };
 

--- a/src/admin/public/types.ts
+++ b/src/admin/public/types.ts
@@ -5,7 +5,7 @@ export type InitPoolTxParam = {
   initSqrtPrice: BN;
   tokenMintA: Address;
   tokenMintB: Address;
-  stable: boolean;
+  tickSpacing: number;
 };
 
 export type CollectProtocolFeesTxParam = {

--- a/src/pool/convert-data.ts
+++ b/src/pool/convert-data.ts
@@ -5,7 +5,7 @@ import { OrcaDAL } from "../dal/orca-dal";
 import { PoolData } from "../types";
 import { toPubKey } from "../utils/address";
 import { DecimalUtil } from "../utils/public/decimal-utils";
-import { fromX64, TickSpacing } from "@orca-so/whirlpool-client-sdk";
+import { fromX64 } from "@orca-so/whirlpool-client-sdk";
 import { TickUtil } from "../utils/whirlpool/tick-util";
 import { sqrtPriceX64ToPrice } from "../utils/public";
 
@@ -98,7 +98,7 @@ export async function convertWhirlpoolDataToPoolData(
       address: toPubKey(address),
       tokenMintA: pool.tokenMintA,
       tokenMintB: pool.tokenMintB,
-      stable: pool.tickSpacing === TickSpacing.Stable,
+      tickSpacing: pool.tickSpacing,
       feeRate: pool.feeRate,
       protocolFeeRate: pool.protocolFeeRate,
       liquidity: pool.liquidity,

--- a/src/pool/orca-pool.ts
+++ b/src/pool/orca-pool.ts
@@ -31,7 +31,6 @@ import { TickUtil } from "../utils/whirlpool/tick-util";
 import { getLiquidityDistribution, LiquidityDistribution } from "./ux/liquidity-distribution";
 import { AmountSpecified, SwapDirection, SwapSimulator } from "./quotes/swap-quoter";
 import {
-  TickSpacing,
   PDA,
   getWhirlpoolPda,
   getTickArrayPda,
@@ -85,14 +84,14 @@ export class OrcaPool {
    * @param stable
    * @returns
    */
-  public derivePDA(tokenMintA: Address, tokenMintB: Address, stable: boolean): PDA {
+  public derivePDA(tokenMintA: Address, tokenMintB: Address, tickSpacing: number): PDA {
     const [_tokenMintA, _tokenMintB] = PoolUtil.orderMints(tokenMintA, tokenMintB);
     return getWhirlpoolPda(
       this.dal.programId,
       this.dal.whirlpoolsConfig,
       toPubKey(_tokenMintA),
       toPubKey(_tokenMintB),
-      stable ? TickSpacing.Stable : TickSpacing.Standard
+      tickSpacing
     );
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,7 +8,7 @@ export type PoolData = {
   address: PublicKey;
   tokenMintA: PublicKey;
   tokenMintB: PublicKey;
-  stable: boolean;
+  tickSpacing: number;
   feeRate: number;
   protocolFeeRate: number;
   liquidity: BN;

--- a/src/utils/public/tick.ts
+++ b/src/utils/public/tick.ts
@@ -2,15 +2,13 @@ import {
   fromX64,
   sqrtPriceX64ToTickIndex,
   tickIndexToSqrtPriceX64,
-  TickSpacing,
   toX64,
 } from "@orca-so/whirlpool-client-sdk";
 import { BN } from "@project-serum/anchor";
 import Decimal from "decimal.js";
 import { TickUtil } from "../whirlpool/tick-util";
 
-export function getNearestValidTickIndexFromTickIndex(tickIndex: number, stable = false) {
-  const tickSpacing = stable ? TickSpacing.Stable : TickSpacing.Standard;
+export function getNearestValidTickIndexFromTickIndex(tickIndex: number, tickSpacing: number) {
   return TickUtil.toValid(tickIndex, tickSpacing);
 }
 
@@ -18,19 +16,16 @@ export function getNearestValidTickIndex(
   price: Decimal,
   decimalsA: number,
   decimalsB: number,
-  stable = false
+  tickSpacing: number
 ) {
-  const tickSpacing = stable ? TickSpacing.Stable : TickSpacing.Standard;
   return TickUtil.toValid(priceToTickIndex(price, decimalsA, decimalsB), tickSpacing);
 }
 
-export function getNextValidTickIndex(tickIndex: number, stable = false) {
-  const tickSpacing = stable ? TickSpacing.Stable : TickSpacing.Standard;
+export function getNextValidTickIndex(tickIndex: number, tickSpacing: number) {
   return tickIndex + tickSpacing;
 }
 
-export function getPrevValidTickIndex(tickIndex: number, stable = false) {
-  const tickSpacing = stable ? TickSpacing.Stable : TickSpacing.Standard;
+export function getPrevValidTickIndex(tickIndex: number, tickSpacing: number) {
   return tickIndex - tickSpacing;
 }
 

--- a/src/utils/whirlpool/tick-util.ts
+++ b/src/utils/whirlpool/tick-util.ts
@@ -2,7 +2,6 @@ import invariant from "tiny-invariant";
 import { Address, BN } from "@project-serum/anchor";
 import { toPubKey } from "../address";
 import {
-  TickSpacing,
   TickArrayData,
   TickData,
   PDA,
@@ -26,7 +25,7 @@ export class TickUtil {
    * Get the nearest (rounding down) valid tick index from the tickIndex.
    * A valid tick index is a point on the tick spacing grid line.
    */
-  public static toValid(tickIndex: number, tickSpacing: TickSpacing): number {
+  public static toValid(tickIndex: number, tickSpacing: number): number {
     return tickIndex - (tickIndex % tickSpacing);
   }
 
@@ -36,7 +35,7 @@ export class TickUtil {
   public static getTick(
     tickArray: TickArrayData,
     tickIndex: number,
-    tickSpacing: TickSpacing
+    tickSpacing: number
   ): TickData {
     const realIndex = TickUtil.tickIndexToTickArrayIndex(tickArray, tickIndex, tickSpacing);
     const tick = tickArray.ticks[realIndex];
@@ -47,7 +46,7 @@ export class TickUtil {
   public static getLowerAndUpperTickArrayAddresses(
     tickLowerIndex: number,
     tickUpperIndex: number,
-    tickSpacing: TickSpacing,
+    tickSpacing: number,
     whirlpool: PublicKey,
     programId: PublicKey
   ): [PublicKey, PublicKey] {
@@ -63,7 +62,7 @@ export class TickUtil {
    */
   public static getPdaWithTickIndex(
     tickIndex: number,
-    tickSpacing: TickSpacing,
+    tickSpacing: number,
     whirlpool: Address,
     programId: Address,
     tickArrayOffset = 0
@@ -74,7 +73,7 @@ export class TickUtil {
 
   public static getPDAWithSqrtPrice(
     sqrtPriceX64: BN,
-    tickSpacing: TickSpacing,
+    tickSpacing: number,
     whirlpool: Address,
     programId: Address,
     tickArrayOffset = 0
@@ -97,7 +96,7 @@ export class TickUtil {
    * @param offset can be used to get neighboring tick array startIndex.
    * @returns
    */
-  public static getStartTickIndex(tickIndex: number, tickSpacing: TickSpacing, offset = 0): number {
+  public static getStartTickIndex(tickIndex: number, tickSpacing: number, offset = 0): number {
     const realIndex = Math.floor(tickIndex / tickSpacing / TICK_ARRAY_SIZE);
     const startTickIndex = (realIndex + offset) * tickSpacing * TICK_ARRAY_SIZE;
 
@@ -114,7 +113,7 @@ export class TickUtil {
   public static getPrevInitializedTickIndex(
     account: TickArrayData,
     currentTickIndex: number,
-    tickSpacing: TickSpacing
+    tickSpacing: number
   ): number | null {
     return TickUtil.findInitializedTick(
       account,
@@ -130,7 +129,7 @@ export class TickUtil {
   public static getNextInitializedTickIndex(
     account: TickArrayData,
     currentTickIndex: number,
-    tickSpacing: TickSpacing
+    tickSpacing: number
   ): number | null {
     return TickUtil.findInitializedTick(
       account,
@@ -143,7 +142,7 @@ export class TickUtil {
   private static findInitializedTick(
     account: TickArrayData,
     currentTickIndex: number,
-    tickSpacing: TickSpacing,
+    tickSpacing: number,
     searchDirection: TickSearchDirection
   ): number | null {
     const currentTickArrayIndex = TickUtil.tickIndexToTickArrayIndex(
@@ -179,7 +178,7 @@ export class TickUtil {
   private static tickIndexToTickArrayIndex(
     { startTickIndex }: TickArrayData,
     tickIndex: number,
-    tickSpacing: TickSpacing
+    tickSpacing: number
   ): number {
     return Math.floor((tickIndex - startTickIndex) / tickSpacing);
   }
@@ -187,7 +186,7 @@ export class TickUtil {
   private static tickArrayIndexToTickIndex(
     { startTickIndex }: TickArrayData,
     tickArrayIndex: number,
-    tickSpacing: TickSpacing
+    tickSpacing: number
   ): number {
     return startTickIndex + tickArrayIndex * tickSpacing;
   }

--- a/test/e2e/add-liquidity-e2e.test.ts
+++ b/test/e2e/add-liquidity-e2e.test.ts
@@ -33,7 +33,8 @@ describe.skip("Add liquidity", () => {
     const { tokenMintA, poolAddress } = await initPool(
       orcaAdmin,
       provider,
-      toX64(new Decimal(1.0005))
+      toX64(new Decimal(1.0005)),
+      64
     );
 
     // initialize client

--- a/test/e2e/swap-e2e.test.ts
+++ b/test/e2e/swap-e2e.test.ts
@@ -1,4 +1,4 @@
-import { TickSpacing, toX64 } from "@orca-so/whirlpool-client-sdk";
+import { toX64 } from "@orca-so/whirlpool-client-sdk";
 import { BN, Provider } from "@project-serum/anchor";
 import { PublicKey } from "@solana/web3.js";
 import { Decimal } from "decimal.js";
@@ -9,7 +9,6 @@ import { getDefaultOffchainDataURI } from "../../src/constants/public/defaults";
 import { OrcaDAL } from "../../src/dal/orca-dal";
 import { ZERO } from "../../src/utils/web3/math-utils";
 import {
-  DEFAULT_FEE_RATE,
   initPoolWithLiquidity,
   initStandardPoolWithLiquidity,
   initWhirlpoolsConfig,
@@ -97,6 +96,7 @@ describe.skip("Swap", () => {
       orcaAdmin,
       provider,
       toX64(new Decimal(1.0005)),
+      64,
       [
         {
           tickLowerIndex: -128,
@@ -159,6 +159,7 @@ describe.skip("Swap", () => {
       orcaAdmin,
       provider,
       toX64(new Decimal(1.0005)),
+      64,
       [
         {
           tickLowerIndex: -128,
@@ -222,6 +223,7 @@ describe.skip("Swap", () => {
       orcaAdmin,
       provider,
       toX64(new Decimal(1.0005)),
+      64,
       [
         {
           tickLowerIndex: -128,
@@ -285,6 +287,7 @@ describe.skip("Swap", () => {
       orcaAdmin,
       provider,
       toX64(new Decimal(1.0005)),
+      64,
       [
         {
           tickLowerIndex: -128,


### PR DESCRIPTION
- Remove usage of TickSpacing enum as it's been removed in client-sdk
- Remove stable and convert to use tick-space number instead.
- Default to tick-spacing 64 for standard.

https://github.com/orca-so/whirlpool/pull/204