### PR TITLE
Update liquidity quotes to include non-adjusted values

### DIFF
--- a/src/pool/public/types.ts
+++ b/src/pool/public/types.ts
@@ -2,7 +2,6 @@ import { u64 } from "@solana/spl-token";
 import { Address, BN, Provider } from "@project-serum/anchor";
 import Decimal from "decimal.js";
 import { Percentage } from "../../utils/public/percentage";
-import { RemoveLiquidityQuote } from "../../position/public";
 
 /*** Transactions ***/
 

--- a/src/pool/public/types.ts
+++ b/src/pool/public/types.ts
@@ -66,10 +66,10 @@ export type ClosePositionQuoteParam = {
 
 export type ClosePositionQuote = {
   positionAddress: Address;
-  minTokenA: BN;
-  minTokenB: BN;
-  estTokenA: BN;
-  estTokenB: BN;
+  minTokenA: u64;
+  minTokenB: u64;
+  estTokenA: u64;
+  estTokenB: u64;
   liquidity: BN;
 };
 

--- a/src/pool/public/types.ts
+++ b/src/pool/public/types.ts
@@ -2,6 +2,7 @@ import { u64 } from "@solana/spl-token";
 import { Address, BN, Provider } from "@project-serum/anchor";
 import Decimal from "decimal.js";
 import { Percentage } from "../../utils/public/percentage";
+import { RemoveLiquidityQuote } from "../../position/public";
 
 /*** Transactions ***/
 
@@ -53,6 +54,8 @@ export type OpenPositionQuote = {
   tickUpperIndex: number;
   maxTokenA: u64;
   maxTokenB: u64;
+  estTokenA: u64;
+  estTokenB: u64;
   liquidity: BN;
 };
 
@@ -64,8 +67,10 @@ export type ClosePositionQuoteParam = {
 
 export type ClosePositionQuote = {
   positionAddress: Address;
-  minTokenA: u64;
-  minTokenB: u64;
+  minTokenA: BN;
+  minTokenB: BN;
+  estTokenA: BN;
+  estTokenB: BN;
   liquidity: BN;
 };
 

--- a/src/position/public/types.ts
+++ b/src/position/public/types.ts
@@ -40,6 +40,8 @@ export type AddLiquidityQuote = {
   positionAddress: Address;
   maxTokenA: BN;
   maxTokenB: BN;
+  estTokenA: BN;
+  estTokenB: BN;
   liquidity: BN;
 };
 
@@ -54,6 +56,8 @@ export type RemoveLiquidityQuote = {
   positionAddress: Address;
   minTokenA: BN;
   minTokenB: BN;
+  estTokenA: BN;
+  estTokenB: BN;
   liquidity: BN;
 };
 

--- a/src/position/quotes/add-liquidity.ts
+++ b/src/position/quotes/add-liquidity.ts
@@ -70,6 +70,8 @@ function getAddLiquidityQuoteWhenPositionIsBelowRange(
     return {
       maxTokenA: ZERO,
       maxTokenB: ZERO,
+      estTokenA: ZERO,
+      estTokenB: ZERO,
       liquidity: ZERO,
     };
   }
@@ -84,16 +86,14 @@ function getAddLiquidityQuoteWhenPositionIsBelowRange(
     false
   );
 
-  const maxTokenA = adjustForSlippage(
-    getTokenAFromLiquidity(liquidity, sqrtPriceLowerX64, sqrtPriceUpperX64, true),
-    slippageTolerance,
-    true
-  );
-  const maxTokenB = ZERO;
+  const estTokenA = getTokenAFromLiquidity(liquidity, sqrtPriceLowerX64, sqrtPriceUpperX64, true);
+  const maxTokenA = adjustForSlippage(estTokenA, slippageTolerance, true);
 
   return {
     maxTokenA,
-    maxTokenB,
+    maxTokenB: ZERO,
+    estTokenA,
+    estTokenB: ZERO,
     liquidity,
   };
 }
@@ -115,30 +115,32 @@ function getAddLiquidityQuoteWhenPositionIsInRange(
   const sqrtPriceLowerX64 = tickIndexToSqrtPriceX64(tickLowerIndex);
   const sqrtPriceUpperX64 = tickIndexToSqrtPriceX64(tickUpperIndex);
 
-  let [tokenAmountA, tokenAmountB] = tokenMintA.equals(inputTokenMint)
+  let [estTokenA, estTokenB] = tokenMintA.equals(inputTokenMint)
     ? [inputTokenAmount, undefined]
     : [undefined, inputTokenAmount];
 
   let liquidity: BN;
 
-  if (tokenAmountA) {
-    liquidity = getLiquidityFromTokenA(tokenAmountA, sqrtPriceX64, sqrtPriceUpperX64, false);
-    tokenAmountA = getTokenAFromLiquidity(liquidity, sqrtPriceX64, sqrtPriceUpperX64, true);
-    tokenAmountB = getTokenBFromLiquidity(liquidity, sqrtPriceLowerX64, sqrtPriceX64, true);
-  } else if (tokenAmountB) {
-    liquidity = getLiquidityFromTokenB(tokenAmountB, sqrtPriceLowerX64, sqrtPriceX64, false);
-    tokenAmountA = getTokenAFromLiquidity(liquidity, sqrtPriceX64, sqrtPriceUpperX64, true);
-    tokenAmountB = getTokenBFromLiquidity(liquidity, sqrtPriceLowerX64, sqrtPriceX64, true);
+  if (estTokenA) {
+    liquidity = getLiquidityFromTokenA(estTokenA, sqrtPriceX64, sqrtPriceUpperX64, false);
+    estTokenA = getTokenAFromLiquidity(liquidity, sqrtPriceX64, sqrtPriceUpperX64, true);
+    estTokenB = getTokenBFromLiquidity(liquidity, sqrtPriceLowerX64, sqrtPriceX64, true);
+  } else if (estTokenB) {
+    liquidity = getLiquidityFromTokenB(estTokenB, sqrtPriceLowerX64, sqrtPriceX64, false);
+    estTokenA = getTokenAFromLiquidity(liquidity, sqrtPriceX64, sqrtPriceUpperX64, true);
+    estTokenB = getTokenBFromLiquidity(liquidity, sqrtPriceLowerX64, sqrtPriceX64, true);
   } else {
     throw new Error("invariant violation");
   }
 
-  const maxTokenA = adjustForSlippage(tokenAmountA, slippageTolerance, true);
-  const maxTokenB = adjustForSlippage(tokenAmountB, slippageTolerance, true);
+  const maxTokenA = adjustForSlippage(estTokenA, slippageTolerance, true);
+  const maxTokenB = adjustForSlippage(estTokenB, slippageTolerance, true);
 
   return {
     maxTokenA,
     maxTokenB,
+    estTokenA,
+    estTokenB,
     liquidity,
   };
 }
@@ -159,6 +161,8 @@ function getAddLiquidityQuoteWhenPositionIsAboveRange(
     return {
       maxTokenA: ZERO,
       maxTokenB: ZERO,
+      estTokenA: ZERO,
+      estTokenB: ZERO,
       liquidity: ZERO,
     };
   }
@@ -172,16 +176,14 @@ function getAddLiquidityQuoteWhenPositionIsAboveRange(
     false
   );
 
-  const maxTokenA = ZERO;
-  const maxTokenB = adjustForSlippage(
-    getTokenBFromLiquidity(liquidity, sqrtPriceLowerX64, sqrtPriceUpperX64, true),
-    slippageTolerance,
-    true
-  );
+  const estTokenB = getTokenBFromLiquidity(liquidity, sqrtPriceLowerX64, sqrtPriceUpperX64, true);
+  const maxTokenB = adjustForSlippage(estTokenB, slippageTolerance, true);
 
   return {
-    maxTokenA,
+    maxTokenA: ZERO,
     maxTokenB,
+    estTokenA: ZERO,
+    estTokenB,
     liquidity,
   };
 }

--- a/src/position/quotes/remove-liquidity.ts
+++ b/src/position/quotes/remove-liquidity.ts
@@ -52,16 +52,15 @@ function getRemoveLiquidityQuoteWhenPositionIsBelowRange(
   const sqrtPriceLowerX64 = tickIndexToSqrtPriceX64(tickLowerIndex);
   const sqrtPriceUpperX64 = tickIndexToSqrtPriceX64(tickUpperIndex);
 
-  const minTokenA = adjustForSlippage(
-    getTokenAFromLiquidity(liquidity, sqrtPriceLowerX64, sqrtPriceUpperX64, false),
-    slippageTolerance,
-    false
-  );
+  const estTokenA = getTokenAFromLiquidity(liquidity, sqrtPriceLowerX64, sqrtPriceUpperX64, false);
+  const minTokenA = adjustForSlippage(estTokenA, slippageTolerance, false);
 
   return {
     positionAddress,
     minTokenA,
     minTokenB: ZERO,
+    estTokenA,
+    estTokenB: ZERO,
     liquidity,
   };
 }
@@ -82,21 +81,18 @@ function getRemoveLiquidityQuoteWhenPositionIsInRange(
   const sqrtPriceLowerX64 = tickIndexToSqrtPriceX64(tickLowerIndex);
   const sqrtPriceUpperX64 = tickIndexToSqrtPriceX64(tickUpperIndex);
 
-  const minTokenA = adjustForSlippage(
-    getTokenAFromLiquidity(liquidity, sqrtPriceX64, sqrtPriceUpperX64, false),
-    slippageTolerance,
-    false
-  );
-  const minTokenB = adjustForSlippage(
-    getTokenBFromLiquidity(liquidity, sqrtPriceLowerX64, sqrtPriceX64, false),
-    slippageTolerance,
-    false
-  );
+  const estTokenA = getTokenAFromLiquidity(liquidity, sqrtPriceX64, sqrtPriceUpperX64, false);
+  const minTokenA = adjustForSlippage(estTokenA, slippageTolerance, false);
+
+  const estTokenB = getTokenBFromLiquidity(liquidity, sqrtPriceLowerX64, sqrtPriceX64, false);
+  const minTokenB = adjustForSlippage(estTokenB, slippageTolerance, false);
 
   return {
     positionAddress,
     minTokenA,
     minTokenB,
+    estTokenA,
+    estTokenB,
     liquidity,
   };
 }
@@ -115,16 +111,15 @@ function getRemoveLiquidityQuoteWhenPositionIsAboveRange(
   const sqrtPriceLowerX64 = tickIndexToSqrtPriceX64(tickLowerIndex);
   const sqrtPriceUpperX64 = tickIndexToSqrtPriceX64(tickUpperIndex);
 
-  const minTokenB = adjustForSlippage(
-    getTokenBFromLiquidity(liquidity, sqrtPriceLowerX64, sqrtPriceUpperX64, false),
-    slippageTolerance,
-    false
-  );
+  const estTokenB = getTokenBFromLiquidity(liquidity, sqrtPriceLowerX64, sqrtPriceUpperX64, false);
+  const minTokenB = adjustForSlippage(estTokenB, slippageTolerance, false);
 
   return {
     positionAddress,
     minTokenA: ZERO,
     minTokenB,
+    estTokenA: ZERO,
+    estTokenB,
     liquidity,
   };
 }


### PR DESCRIPTION
1. Swap already separates out the slippage adjusted as the `otherAmountThreshold`
2. Open position/add liquidity uses a slippage_tolerance of `0` when modifying amounts to add, so the slipped number isn't shown
3. Needs to update orca-ui to pick up changes